### PR TITLE
Action Network's search_by value now must be email_address for emails.

### DIFF
--- a/pyactionnetwork/api.py
+++ b/pyactionnetwork/api.py
@@ -48,12 +48,12 @@ class ActionNetworkApi:
         url = self.resource_to_url(resource)
         return requests.get(url, headers=self.headers).json()
 
-    def get_person(self, person_id=None, search_by='email', search_string=None):
+    def get_person(self, person_id=None, search_by='email_address', search_string=None):
         """Search for a user.
 
         Args:
             search_by (str):
-                Field by which to search for a user. 'email' is the default.
+                Field by which to search for a user. 'email_address' is the default.
             search_string (str):
                 String to search for within the field given by `search_by`
 


### PR DESCRIPTION
## Description
Action Network's search_by value now must be email_address for emails.

## Motivation and Context
Fixes https://github.com/PhillyDSA/pyactionnetwork/issues/16

## How Has This Been Tested?
I have been using this for weeks.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read and agreed to the PhillyDSA Tech Team Code of Conduct
