### PR TITLE
models: Tagging: __repr__: Do not include name.

### DIFF
--- a/pyactionnetwork/models.py
+++ b/pyactionnetwork/models.py
@@ -86,7 +86,7 @@ class Tagging(ANBaseModel):
     """
 
     def __repr__(self):
-        return 'Tagging(id={0}, name={1})'.format(self.id, self.name)
+        return 'Tagging(id={0})'.format(self.id)
 
 
 class Person(ANBaseModel):


### PR DESCRIPTION
## Description
Fix https://github.com/PhillyDSA/pyactionnetwork/issues/21 by avoiding printing `Tagging` names.

## Motivation and Context
It allows printing `Tagging`s

## How Has This Been Tested?
I tested this in my fork at https://github.com/fishinthecalculator/pyactionnetwork/tree/live

# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read and agreed to the PhillyDSA Tech Team Code of Conduct
